### PR TITLE
Removed minimalrebuild from debug.props.

### DIFF
--- a/build/settings/debug.props
+++ b/build/settings/debug.props
@@ -14,7 +14,6 @@
     <ClCompile>
       <StringPooling>true</StringPooling>
       <Optimization>Disabled</Optimization>
-      <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>


### PR DESCRIPTION
Removed deprecated MinimalRebuild from debug.props as a fix for #19.