### PR TITLE
Make the build template more generic

### DIFF
--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -5,12 +5,16 @@ parameters:
   buildConfiguration: 'Release'
   productMajor: 1
   productMinor: 0
+  buildMajor: ''
+  buildMinor: ''
   signType: 'test'
   signingIdentity: 'Microsoft'
   teamName: 'IIS'
   indexSourcesAndPublishSymbols: 'false'
   publishArtifactInstallers: 'false'
   publishArtifactSources: 'false'
+  whiteListPathForAuthenticodeSign: ''
+  whiteListPathForStrongNameSign: ''
 
 jobs:
 - job: build
@@ -67,7 +71,7 @@ jobs:
     inputs:
       solution: ${{ parameters.solution }}
       vsVersion: 15.0
-      msbuildArgs: '/p:PRODUCT_MAJOR=${{ parameters.productMajor }} /p:PRODUCT_MINOR=${{ parameters.productMinor }} /p:BUILD_MAJOR=$(Build.BuildNumber) /p:SignType=${{ parameters.signType }} /p:SigningIdentity=${{ parameters.signingIdentity }}'
+      msbuildArgs: '/p:PRODUCT_MAJOR=${{ parameters.productMajor }} /p:PRODUCT_MINOR=${{ parameters.productMinor }} /p:BUILD_MAJOR=${{ parameters.buildMajor }} /p:BUILD_MINOR=${{ parameters.buildMinor }} /p:SignType=${{ parameters.signType }} /p:SigningIdentity=${{ parameters.signingIdentity }}'
       platform: x86
       configuration: ${{ parameters.buildConfiguration }}
       clean: true
@@ -78,7 +82,7 @@ jobs:
     inputs:
       solution: ${{ parameters.solution }}
       vsVersion: 15.0
-      msbuildArgs: '/p:PRODUCT_MAJOR=${{ parameters.productMajor }} /p:PRODUCT_MINOR=${{ parameters.productMinor }} /p:BUILD_MAJOR=$(Build.BuildNumber) /p:SignType=${{ parameters.signType }} /p:SigningIdentity=${{ parameters.signingIdentity }}'
+      msbuildArgs: '/p:PRODUCT_MAJOR=${{ parameters.productMajor }} /p:PRODUCT_MINOR=${{ parameters.productMinor }} /p:BUILD_MAJOR=${{ parameters.buildMajor }} /p:BUILD_MINOR=${{ parameters.buildMinor }} /p:SignType=${{ parameters.signType }} /p:SigningIdentity=${{ parameters.signingIdentity }}'
       platform: x64
       configuration: ${{ parameters.buildConfiguration }}
       clean: true
@@ -137,7 +141,8 @@ jobs:
       displayName: 'Verify Signed Binaries'
       inputs:
         TargetFolders: '$(Build.ArtifactStagingDirectory)\Binaries'
-        WhiteListPathForCerts: '$(Build.SourcesDirectory)\.pipelines\templates\no_authenticode.txt'
+        WhiteListPathForCerts: ${{ parameters.whiteListPathForAuthenticodeSign }}
+        WhiteListPathForSigs: ${{ parameters.whiteListPathForStrongNameSign }}
 
   - ${{ if and(eq(parameters.signType, 'real'), eq(parameters.publishArtifactInstallers, 'true')) }}:
     - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@2

--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -3,8 +3,8 @@ parameters:
   agentPoolDemandTeam: ''
   solution: '**\*.sln'
   buildConfiguration: 'Release'
-  productMajor: 1
-  productMinor: 0
+  productMajor: ''
+  productMinor: ''
   buildMajor: ''
   buildMinor: ''
   signType: 'test'


### PR DESCRIPTION
Converted a couple of hard-coded build task properties (originally used by IIS.Compression) to pipeline parameters to make the template more generic.