### PR TITLE
Fix build error with the default buildMajor and buildMinor

### DIFF
--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -94,7 +94,7 @@ jobs:
                $MsbuildArgs += "/p:$($key)=$($MsbuildArgsDict[$key]) "
            }
        }
-       Write-Host "$("##vso[task.setvariable variable=msbuildArgs]") $($MsbuildArgs)"
+       Write-Host "$("##vso[task.setvariable variable=MsbuildArgs]") $($MsbuildArgs)"
        Write-Host "MsbuildArgs: $($MsbuildArgs)"
 
   - task: VSBuild@1

--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -29,6 +29,12 @@ jobs:
 
   variables:
     TeamName: ${{ parameters.teamName }} # required by MicroBuildTasks
+    ProductMajor: ${{ parameters.productMajor }}
+    ProductMinor: ${{ parameters.productMinor }}
+    BuildMajor: ${{ parameters.buildMajor }}
+    BuildMinor: ${{ parameters.buildMinor }}
+    SignType: ${{ parameters.signType }}
+    SigningIdentity: ${{ parameters.signingIdentity }}
 
   steps:
   - checkout: self
@@ -66,12 +72,37 @@ jobs:
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0 
     displayName: 'Component Detection'
 
+  - task: PowerShell@2
+    displayName: 'Process Msbuild Arguments'
+    inputs:
+      targetType: inline
+      script: |
+       $MsbuildArgsDict =
+       @{
+           "ProductMajor" = $env:PRODUCTMAJOR;
+           "ProductMinor" = $env:PRODUCTMINOR;
+           "BuildMajor" = $env:BUILDMAJOR;
+           "BuildMinor" = $env:BUILDMINOR;
+           "SignType" = $env:SIGNTYPE;
+           "SigningIdentity" = $env:SIGNIDENTITY;
+       };
+       $MsbuildArgs = ""
+       foreach ($key in $MsbuildArgsDict.Keys)
+       {
+           if (![string]::IsNullOrEmpty($MsbuildArgsDict[$key]))
+           {
+               $MsbuildArgs += "/p:$($key)=$($MsbuildArgsDict[$key]) "
+           }
+       }
+       Write-Host "$("##vso[task.setvariable variable=msbuildArgs]") $($MsbuildArgs)"
+       Write-Host "MsbuildArgs: $($MsbuildArgs)"
+
   - task: VSBuild@1
     displayName: 'Build x86'
     inputs:
       solution: ${{ parameters.solution }}
       vsVersion: 15.0
-      msbuildArgs: '/p:PRODUCT_MAJOR=${{ parameters.productMajor }} /p:PRODUCT_MINOR=${{ parameters.productMinor }} /p:BUILD_MAJOR=${{ parameters.buildMajor }} /p:BUILD_MINOR=${{ parameters.buildMinor }} /p:SignType=${{ parameters.signType }} /p:SigningIdentity=${{ parameters.signingIdentity }}'
+      msbuildArgs: $(MsbuildArgs)
       platform: x86
       configuration: ${{ parameters.buildConfiguration }}
       clean: true
@@ -82,7 +113,7 @@ jobs:
     inputs:
       solution: ${{ parameters.solution }}
       vsVersion: 15.0
-      msbuildArgs: '/p:PRODUCT_MAJOR=${{ parameters.productMajor }} /p:PRODUCT_MINOR=${{ parameters.productMinor }} /p:BUILD_MAJOR=${{ parameters.buildMajor }} /p:BUILD_MINOR=${{ parameters.buildMinor }} /p:SignType=${{ parameters.signType }} /p:SigningIdentity=${{ parameters.signingIdentity }}'
+      msbuildArgs: $(MsbuildArgs)
       platform: x64
       configuration: ${{ parameters.buildConfiguration }}
       clean: true

--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -84,7 +84,7 @@ jobs:
            "BuildMajor" = $env:BUILDMAJOR;
            "BuildMinor" = $env:BUILDMINOR;
            "SignType" = $env:SIGNTYPE;
-           "SigningIdentity" = $env:SIGNIDENTITY;
+           "SigningIdentity" = $env:SIGNINGIDENTITY;
        };
        $MsbuildArgs = ""
        foreach ($key in $MsbuildArgsDict.Keys)


### PR DESCRIPTION
In the current build pipeline template, we use empty string as the default value of PRODUCT_MAJOR, PRODUCT_MINOR, BUILD_MAJOR, BUILD_MINOR and pass all these properties to msbuild.

In our verisons.props, we have algorithms to generate BUILD_MAJOR and BUILD_MINOR based on time stamp if they are not present or if they are empty strings. So the original expectation was the below command would work with BUILD_MAJOR, BUILD_MINOR auto generated based on the time stamp:

msbuild compression.sln /p:platform="x86" /p:configuration="Release" /p:PRODUCT_MAJOR=1 /p:PRODUCT_MINOR=0 **/p:BUILD_MAJOR= /p:BUILD_MINOR=**

However, the build actually fails with empty BUILD_MAJOR and BUILD_MINOR.

The root cause is that the command line passed-in properties are always set AFTER the property setting defined in versions.props and hence the former always wins.

See the exact same issue discussed here:
https://social.msdn.microsoft.com/Forums/vstudio/en-US/4e777a1e-2627-40cf-b624-88f8f6dd7e52/how-do-i-test-for-empty-properties-set-on-the-command-line?forum=msbuild

So the workaround of using the auto-generated BUILD_MAJOR and BUILD_MINOR is NOT passing them to msbuild:

msbuild compression.sln /p:platform="x86" /p:configuration="Release" /p:PRODUCT_MAJOR=1 /p:PRODUCT_MINOR=0

To implement the workaround, I added a Powershell task to parse the msbuild-related variables and to generate a new MsbuildArgs pipeline variable for the following msbuild tasks.

There might be a better way to directly consume template parameters in Powershell task. But for now, I use pipeline variables instead for simplicity. We can improve it later if necessary.