### PR TITLE
Update WhiteListPathForCerts for "Verify Signed Installers" task and fix msbuild arguments

### DIFF
--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -79,10 +79,10 @@ jobs:
       script: |
        $MsbuildArgsDict =
        @{
-           "ProductMajor" = $env:PRODUCTMAJOR;
-           "ProductMinor" = $env:PRODUCTMINOR;
-           "BuildMajor" = $env:BUILDMAJOR;
-           "BuildMinor" = $env:BUILDMINOR;
+           "PRODUCT_MAJOR" = $env:PRODUCTMAJOR;
+           "PRODUCT_MINOR" = $env:PRODUCTMINOR;
+           "BUILD_MAJOR" = $env:BUILDMAJOR;
+           "BUILD_MINOR" = $env:BUILDMINOR;
            "SignType" = $env:SIGNTYPE;
            "SigningIdentity" = $env:SIGNINGIDENTITY;
        };

--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -180,7 +180,7 @@ jobs:
       displayName: 'Verify Signed Installers'
       inputs:
         TargetFolders: '$(Build.ArtifactStagingDirectory)\Installers'
-        WhiteListPathForCerts: '$(Build.SourcesDirectory)\.pipelines\templates\no_authenticode.txt'
+        WhiteListPathForCerts: ${{ parameters.whiteListPathForAuthenticodeSign }}
 
   - ${{ if eq(parameters.indexSourcesAndPublishSymbols, 'true') }}:
     - task: PublishSymbols@2


### PR DESCRIPTION
Forgot to update the hard-coded WhiteListPathForCerts in the previous PR: https://github.com/microsoft/IIS.Common/pull/22

Fixed the bug on msbuild arguments introduced by https://github.com/microsoft/IIS.Common/pull/24