### PR TITLE
Update build.yml

### DIFF
--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -55,6 +55,7 @@ jobs:
     displayName: 'Install Signing Plugin'
     inputs:
       signType: ${{ parameters.signType }}
+      version: 1.1.282
 
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet Tool'


### PR DESCRIPTION
Added version: 1.1.282 because we ran into the below error with the latest version(1.1.307).
```
##[error]E:\A\_work\42\a\MicroBuild\Plugins\MicroBuild.Plugins.Signing.1.1.307\build\MicroBuild.Plugins.Signing.targets(43,5): Error MSB4062: The "SignFiles" task could not be loaded from the assembly E:\A\_work\42\a\MicroBuild\Plugins\MicroBuild.Plugins.Signing.1.1.307\buildCrossTargeting\\..\build\MicroBuild.Signing.dll. Could not load file or assembly 'netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The system cannot find the file specified. Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask. 
```