### PR TITLE
set version 1.1.282 for signing plugin

### DIFF
--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -55,6 +55,7 @@ jobs:
     displayName: 'Install Signing Plugin'
     inputs:
       signType: ${{ parameters.signType }}
+      version: 1.1.282
 
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet Tool'


### PR DESCRIPTION
set version 1.1.282 for signing plugin as a work around way of the issue on the latest build