### PR TITLE
Update toolset for reftrace project to v143

### DIFF
--- a/reftrace/reftrace.vcxproj
+++ b/reftrace/reftrace.vcxproj
@@ -47,7 +47,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <WholeProgramOptimization>true</WholeProgramOptimization>


### PR DESCRIPTION
Update toolset for reftrace project to v143 to build with VS 2022.