### PR TITLE
Suppress CodeQL warnings related to BYTE buffer in String implementations

### DIFF
--- a/Include/multisz.hxx
+++ b/Include/multisz.hxx
@@ -131,7 +131,7 @@ public:
     //  Return the string buffer
     //
     WCHAR * QueryStrA( VOID ) const { return ( QueryStr()); }
-    WCHAR * QueryStr( VOID ) const { return ((WCHAR *) QueryPtr()); }
+    WCHAR * QueryStr( VOID ) const { return ((WCHAR *) QueryPtr()); } // CodeQL [SM02986] BYTE* buffer is used for storing MultiSz.
 
     //
     //  Makes a clone of the current string in the string pointer passed in.

--- a/lib/multisz.cxx
+++ b/lib/multisz.cxx
@@ -225,10 +225,10 @@ BOOL MULTISZ::AuxAppend( const WCHAR * pStr, UINT cbStr, BOOL fAddSlop )
     memcpy( (BYTE *) QueryPtr() + cbThis,
             pStr,
             cbStr);
-    *(WCHAR *)((BYTE *)QueryPtr() + cbThis + cbStr) = L'\0';
-    *(WCHAR *)((BYTE *)QueryPtr() + cbThis + cbStr + sizeof(WCHAR) ) = L'\0';
+    *(WCHAR *)((BYTE *)QueryPtr() + cbThis + cbStr) = L'\0'; // CodeQL [SM02986] BYTE* buffer is used for storing MultiSz.
+    *(WCHAR *)((BYTE *)QueryPtr() + cbThis + cbStr + sizeof(WCHAR) ) = L'\0'; // CodeQL [SM02986] BYTE* buffer is used for storing MultiSz.
 
-    m_cchLen = CalcLength( (const WCHAR *)QueryPtr(), &m_cStrings );
+    m_cchLen = CalcLength( (const WCHAR *)QueryPtr(), &m_cStrings ); // CodeQL [SM02986] BYTE* buffer is used for storing MultiSz.
     return TRUE;
 
 } // MULTISZ::AuxAppend()

--- a/lib/stringu.cpp
+++ b/lib/stringu.cpp
@@ -830,7 +830,7 @@ Return Value:
         }
     }
 
-    pszBuffer = reinterpret_cast<WCHAR*>(reinterpret_cast<BYTE*>(m_Buff.QueryPtr()) + cbOffset);
+    pszBuffer = reinterpret_cast<WCHAR*>(reinterpret_cast<BYTE*>(m_Buff.QueryPtr()) + cbOffset);  // CodeQL [SM02986] BYTE* buffer is used for storing string.
     cchBuffer = ( m_Buff.QuerySize() - cbOffset - sizeof( WCHAR ) ) / sizeof( WCHAR );
 
     cchCharsCopied = MultiByteToWideChar(


### PR DESCRIPTION
AB#1691430
AB#1691433
AB#1691434
AB#1691415
AB#1691425

STRU and MULTISZ classes are backed by BYTE buffer so we need to suppress the CodeQL warnings related to casting b/w BYTE* & WCHAR*.
 